### PR TITLE
fix: fix dns response ttl when dial_mode == ip

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -461,6 +461,7 @@ func NewControlPlane(
 		},
 		IpVersionPrefer: dnsConfig.IpVersionPrefer,
 		FixedDomainTtl:  fixedDomainTtl,
+		DialMode:        dialMode,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when dial_mode == ip:
1. choose the minimal ttl as cache ttl in dns controller
2. keep the original dns response ttl

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
